### PR TITLE
fix: Adding principal AWS rules as env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@ Action to push images to Amazon's Elastic Container Registry.
 
 ### Usage
 
-You have to set up the target `AWS_ACCOUNT_ID` as an environment variable!
-
 Make sure to checkout the repo so the workflow can see your Dockerfile
-
 
 ```yaml
 on: [push]
@@ -21,17 +18,18 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Docker build and push to ECR
-        uses: olxbr/aws-ecr-push-action@v0.3
+        uses: olxbr/aws-ecr-push-action@v0
         id: ecr
         with:
           # The complete repository name from ECR {BU}/{TEAM}/{PROJECT} (ex. cross/devtools/devtools-scripts).
           ecr_repository: 'cross/devtools/momo'
           # Comma-separated string of ECR image tags (ex. latest, 1.0.0)
           tags: 'latest,0.2.2,beta'
+        # Warning! Don't change this env values!
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_CROSS_ACCOUNT_ID }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_CROSS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_CROSS_SECRET_ACCESS_KEY }}
+          AWS_PRINCIPAL_RULES: ${{ secrets.AWS_PRINCIPAL_RULES }}
 
 ```
-

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const { buildPolicy } = require('./policy');
 const fs = require('fs');
 
 const AWS_ACCOUNT_ID = process.env.AWS_ACCOUNT_ID;
+const AWS_PRINCIPAL_RULES = process.env.AWS_PRINCIPAL_RULES;
 const ECR_ENDPOINT = `${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com`;
 
 const VIRUS_THRESHOLD = 0;
@@ -50,7 +51,7 @@ const describeRepoErrorHandler = (config) => async (err) => {
   }
 
   const repositoryName = config.repositoryNames[0];
-  const policy = buildPolicy({ accountId: AWS_ACCOUNT_ID });
+  const policy = buildPolicy({ awsPrincipalRules: AWS_PRINCIPAL_RULES });
   console.log(`Creating repository ${repositoryName}...`);
   console.log(`Policy: ${policy}`);
 

--- a/policy.js
+++ b/policy.js
@@ -1,11 +1,11 @@
-const buildPolicy = ({ accountId }) => JSON.stringify({
+const buildPolicy = ({ awsPrincipalRules }) => JSON.stringify({
     "Version": "2008-10-17",
     "Statement": [
         {
             "Sid": "AllowPushPull",
             "Effect": "Allow",
             "Principal": {
-                "AWS": `arn:aws:iam::${accountId}:root`
+                "AWS": JSON.parse(awsPrincipalRules)
             },
             "Action": [
                 "ecr:GetDownloadUrlForLayer",


### PR DESCRIPTION
Adding principal AWS rules as env var because we need this information more flexible.