### PR TITLE
Fix cleanup when no containers are running

### DIFF
--- a/cleanup.js
+++ b/cleanup.js
@@ -2,13 +2,24 @@ const { executeSyncCmd } = require('./utils')
 
 const filterEmpty = x => x
 
+console.log('Listing running containers...')
 const containerIds = executeSyncCmd('docker', ['ps', '-aq']).split('\n').filter(filterEmpty)
 
 /*
+ *console.log('Listing docker images...')
  *const imageIds = executeSyncCmd('docker', ['images', '-aq']).split('\n').filter(filterEmpty)
  *
+ *console.log('Listing docker volumes...')
  *const volumeIds = executeSyncCmd('docker', ['volume', 'ls', '-q']).split('\n').filter(filterEmpty)
  */
+
+console.log('============================================')
+console.log(`Running containers: ${containerIds.length}`)
+/*
+ *console.log(`Total images: ${imageIds.length}`)
+ *console.log(`Total volumes: ${volumeIds.length}`)
+ */
+console.log('============================================\n')
 
 for (let id of containerIds) {
   console.log(`Stopping container ${id}`)
@@ -29,3 +40,5 @@ for (let id of containerIds) {
  *}
  *
  */
+
+ console.log('Finished docker cleanup.')

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,9 +1,13 @@
 const { executeSyncCmd } = require('./utils')
 
-const containerIds = executeSyncCmd('docker', ['ps', '-aq']).trim().split('\n')
+const filterEmpty = x => x
+
+const containerIds = executeSyncCmd('docker', ['ps', '-aq']).split('\n').filter(filterEmpty)
+
 /*
- *const imageIds = executeSyncCmd('docker', ['images', '-aq']).trim().split('\n')
- *const volumeIds = executeSyncCmd('docker', ['volume', 'ls', '-q']).trim().split('\n')
+ *const imageIds = executeSyncCmd('docker', ['images', '-aq']).split('\n').filter(filterEmpty)
+ *
+ *const volumeIds = executeSyncCmd('docker', ['volume', 'ls', '-q']).split('\n').filter(filterEmpty)
  */
 
 for (let id of containerIds) {


### PR DESCRIPTION
This PR fixes a bug where the cleanup script would fail when there are no running containers on the runner